### PR TITLE
minor readme changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,6 @@ The Eye is a service designed to add value to applications by storing and aggreg
 * git clone https://github.com/BaronXOfficial/TheEye-ConsumerAffairs.git
 * CD into project directory
 * docker-compose up --build
-
-
-* docker-compose exec django python manage.py makemigrations
 * docker-compose exec django python manage.py migrate
 
 Once initial setup is complete:


### PR DESCRIPTION
Minor readme changes:

Removed unnecessary "makemigrations" instruction, migrations are already included in base project and thus only "migrate" command is necessary.